### PR TITLE
Port updates from main repo

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -95,6 +95,8 @@ test('slots - default and named', () => {
 
 You can provide properties to the App instance using the properties under the `global` mount property.
 
+### `global.provide`
+
 ### `global.mixins`
 
 Applies mixins via `app.mixin(...)`.
@@ -209,8 +211,6 @@ test('installs a directive globally', () => {
 })
 ```
 
-
-### `global.provide`
 
 Provides data to be received in a `setup` function via `inject`.
 


### PR DESCRIPTION
Right now we have 3 versions of VTU-next, now:

1) the one written in code
2) the one written in docs in vtu-next repo
3) the one written in docs in vtu-next-docs repo

This PR is only aimed at porting the docs updates we wrote in the main VTU-next repo, so we end up with a single version of docs.

After this, I'll submit other PR to make sure docs from vtu-next-docs are aligned with the actual implementations. Also, I think I'll be removing docs from vtu-next to make the process somewhat simpler.