### PR TITLE
docs: add native form submission subsection to forms guide

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -27,6 +27,8 @@ test('mounts a component', () => {
 
 Specify where to mount the component. Useful when testing Vue as part of a larger application.
 
+Can be a valid CSS selector, or an [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element) connected to the document.
+
 `Component.vue`
 
 ```vue
@@ -44,7 +46,7 @@ export default {}
 ```js
 test('mounts on a specific element', () => {
   // in a JSDOM environment, such as Jest
-  document.getElementsByTagName('html')[0].innerHTML = `
+  document.body.innerHTML = `
     <div>
       <h1>Non Vue app</h1>
       <div id="app"></div>
@@ -60,7 +62,7 @@ test('mounts on a specific element', () => {
    *   <h1>Non Vue app</h1>
    *   <div>Vue Component</div>
    * </div>
-  */
+   */
 })
 ```
 
@@ -1027,7 +1029,7 @@ test('text', () => {
 Since events often cause a re-render, `trigger` returns `Vue.nextTick`. You should use `await` when you call `trigger` to ensure that Vue updates the DOM before you make an assertion.
 :::
 
-Triggers an event, for example `click`, `submit` or `keyup`.
+Triggers a DOM event, for example `click`, `submit` or `keyup`.
 
 `Component.vue`:
 

--- a/src/guide/forms.md
+++ b/src/guide/forms.md
@@ -226,6 +226,10 @@ Native event modifiers such as `.prevent` and `.stop` are Vue-specific and as su
 
 We then make a simple assertion, whether the form emitted the correct event and payload.
 
+#### Native form submission
+
+Triggering a `submit` event on a `<form>` element mimics browser behavior during form submission. If we wanted to trigger form submission more naturally, we could trigger a `click` event on the submit button instead. However, this necessitates the use of the [`attachTo`](/api/#attachto) mounting option, which connects the wrapper's element to the document. Form elements not connected to the `document` cannot be submitted, as per the [HTML specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm).
+
 #### Multiple modifiers on the same event
 
 Let's assume you have a very detailed and complex form, with special interaction handling. How can we go about testing that?

--- a/src/guide/forms.md
+++ b/src/guide/forms.md
@@ -228,7 +228,7 @@ We then make a simple assertion, whether the form emitted the correct event and 
 
 #### Native form submission
 
-Triggering a `submit` event on a `<form>` element mimics browser behavior during form submission. If we wanted to trigger form submission more naturally, we could trigger a `click` event on the submit button instead. However, this necessitates the use of the [`attachTo`](/api/#attachto) mounting option, which connects the wrapper's element to the document. Form elements not connected to the `document` cannot be submitted, as per the [HTML specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm).
+Triggering a `submit` event on a `<form>` element mimics browser behavior during form submission. If we wanted to trigger form submission more naturally, we could trigger a `click` event on the submit button instead. Since form elements not connected to the `document` cannot be submitted, as per the [HTML specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm), we need to use [`attachTo`](/api/#attachto) to connect the wrapper's element.
 
 #### Multiple modifiers on the same event
 


### PR DESCRIPTION
Added parameter types info to `attachTo` in API reference, and added an example of how to use it in the form handling guide.

The old v1 test-utils documentation had complete lists of arguments and types for each wrapper method, but the new docs do not. Now that everything is written in Typescript, is this something we could auto-generate?

Also, I think if we wanted we could still build these docs within the `vue-test-utils-next` repo. Vuepress doesn't specify `vue` as a peer dependency, so it already installs `vue@2` transitively and references it directly. If we still need `vue@2` from our side, we can just alias it wihtin our `package.json` as `"vue2": "npm:vue@2"`, and either always reference it via `import vue2 from 'vue2'`, or add a Webpack alias to the Vuepress build to resolve references to `vue` -> `vue2`.
