### PR TITLE
Added reference to vm-property in api-reference

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1093,4 +1093,4 @@ test('unmount', () => {
 
 ### `vm`
 
-This is the ```Vue``` instance. You can access all of the [instance methods and properties of a vm](https://vuejs.org/v2/api/#Instance-Properties) with ```wrapper.vm```. This only exists on ```VueWrapper```. 
+This is the ```Vue``` instance. You can access all of the [instance methods and properties of a vm](https://v3.vuejs.org/api/instance-properties.html) with ```wrapper.vm```. This only exists on ```VueWrapper```. 

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1088,3 +1088,9 @@ test('unmount', () => {
   wrapper.unmount() // removed from DOM
 })
 ```
+
+## Wrapper properties
+
+### `vm`
+
+This is the ```Vue``` instance. You can access all of the [instance methods and properties of a vm](https://vuejs.org/v2/api/#Instance-Properties) with ```wrapper.vm```. This only exists on ```VueWrapper```. 


### PR DESCRIPTION
Here's a very small PR adding a section on wrapper properties (more specifically ```vm```) as mentioned in https://github.com/vuejs/vue-test-utils-next/issues/211