### PR TITLE
docs: add `isVisible` section and example

### DIFF
--- a/src/guide/conditional-rendering.md
+++ b/src/guide/conditional-rendering.md
@@ -102,7 +102,7 @@ const Nav = {
   template: `
     <nav>
       <a id="user" href="/profile">My Profile</a>
-      <ul v-show="shouldShowDropdown" id="user-dropdwn">
+      <ul v-show="shouldShowDropdown" id="user-dropdown">
         <!-- dropdown content -->
       </ul>
     </nav>
@@ -126,7 +126,7 @@ test('does not show the user dropdown', () => {
   const wrapper = mount(Nav)
 
   // using `get()` works as well
-  expect(wrapper.find('#user-dropdwn').isVisible()).toBe(false)
+  expect(wrapper.find('#user-dropdown').isVisible()).toBe(false)
 })
 ```
 

--- a/src/guide/conditional-rendering.md
+++ b/src/guide/conditional-rendering.md
@@ -4,7 +4,7 @@ Vue Test Utils has a range of features for rendering and making assertions about
 
 ## Finding Elements
 
-One of the most basic features of Vue is the ability to dynamically show, hide by removing elements with `v-if`. Let's look at how to test a component that uses `v-if`.
+One of the most basic features of Vue is the ability to dynamically insert and remove elements with `v-if`. Let's look at how to test a component that uses `v-if`.
 
 ```js
 const Nav = {
@@ -93,7 +93,7 @@ To learn what other mounting options exist, see [`Passing Data`](./passing-data.
 
 ## Checking Elements visibility
 
-Sometimes you only want to hide/show an element while keeping it in the DOM. Vue offers `v-show` for scenarios as such. (You can check the differences between `v-if` and `v-show` [here](https://vuejs.org/v2/guide/conditional.html#v-if-vs-v-show)).
+Sometimes you only want to hide/show an element while keeping it in the DOM. Vue offers `v-show` for scenarios as such. (You can check the differences between `v-if` and `v-show` [here](https://v3.vuejs.org/guide/conditional.html#v-if-vs-v-show)).
 
 This is how a component with `v-show` looks like:
 
@@ -115,7 +115,7 @@ const Nav = {
 }
 ```
 
-In this scenario, the element is not visible but but it always rendered. `get()` or `find()` will always return a `Wrapper` – `find()` with `.exists()` always return `true` – because the **element is still in the DOM**. 
+In this scenario, the element is not visible but always rendered. `get()` or `find()` will always return a `Wrapper` – `find()` with `.exists()` always return `true` – because the **element is still in the DOM**. 
 
 ## Using `isVisible()`
 
@@ -125,8 +125,7 @@ In this scenario, the element is not visible but but it always rendered. `get()`
 test('does not show the user dropdown', () => {
   const wrapper = mount(Nav)
 
-  // using `get()` works as well
-  expect(wrapper.find('#user-dropdown').isVisible()).toBe(false)
+  expect(wrapper.get('#user-dropdown').isVisible()).toBe(false)
 })
 ```
 
@@ -143,4 +142,4 @@ For any of these cases, `isVisible()` will return `false`.
 - Use `find()` along with `exists()` to verify whether an element is in the DOM.
 - Use `get()` if you expect the element to be in the DOM.
 - The `data` mounting option can be used to set default values on a component.
-- Use `find()` (or `get()`) with `isVisible()` to verify the visibility of an element that is in the DOM
+- Use `get()` with `isVisible()` to verify the visibility of an element that is in the DOM

--- a/src/guide/conditional-rendering.md
+++ b/src/guide/conditional-rendering.md
@@ -4,7 +4,7 @@ Vue Test Utils has a range of features for rendering and making assertions about
 
 ## Finding Elements
 
-One of the most basic features of Vue is the ability to dynamically show, hide and remove elements with `v-if`. Let's look at how to test a component that uses `v-if`.
+One of the most basic features of Vue is the ability to dynamically show, hide by removing elements with `v-if`. Let's look at how to test a component that uses `v-if`.
 
 ```js
 const Nav = {
@@ -50,7 +50,7 @@ If `get()` does not return an element matching the selector, it will raise an er
 
 ## Using `find()` and `exists()`
 
-`get()` works for asserting elements do exist. However, as we mentioned, it throws an error when it can't find an element, so you can't use it to assert whether if elements exist.
+`get()` works on the assumption that elements do exist and throws an error when they do not. It is _not_ recommended to use it for asserting existence.
 
 To do so, we use `find()` and `exists()`. The next test asserts that if `admin` is `false` (which is it by default), the admin link is not present:
 
@@ -63,7 +63,7 @@ test('does not render an admin link', () => {
 })
 ```
 
-Notice we are calling `exists()` on the value returned from `.find()`? `find()`, like `mount()`, also returns a wrapper, similar to `mount()`. `mount()` has a few extra methods, because it's wrapping a Vue component, and `find()` only returns a regular DOM node, but many of the methods are shared between both. Some other methods include `classes()`, which gets the classes a DOM node has, and `trigger()` for simulating user interaction. You can find a list of methods supported [here](.,/api/#wrapper-methods).
+Notice we are calling `exists()` on the value returned from `.find()`? `find()`, like `mount()`, also returns a `wrapper`, similar to `mount()`. `mount()` has a few extra methods, because it's wrapping a Vue component, and `find()` only returns a regular DOM node, but many of the methods are shared between both. Some other methods include `classes()`, which gets the classes a DOM node has, and `trigger()` for simulating user interaction. You can find a list of methods supported [here](.,/api/#wrapper-methods).
 
 ## Using `data`
 
@@ -89,10 +89,58 @@ test('renders an admin link', () => {
 
 If you have other properties in `data`, don't worry - Vue Test Utils will merge the two together. The `data` in the mounting options will take priority over any default values.
 
-To learn what other mounting options exist, see [`Passing Data`]./passing-data.html) or see [`mounting options`](.,/api/#mount-options).
+To learn what other mounting options exist, see [`Passing Data`](./passing-data.html) or see [`mounting options`](.,/api/#mount-options).
+
+## Checking Elements visibility
+
+Sometimes you only want to hide/show an element while keeping it in the DOM. Vue offers `v-show` for scenarios as such. (You can check the differences between `v-if` and `v-show` [here](https://vuejs.org/v2/guide/conditional.html#v-if-vs-v-show)).
+
+This is how a component with `v-show` looks like:
+
+```js
+const Nav = {
+  template: `
+    <nav>
+      <a id="user" href="/profile">My Profile</a>
+      <ul v-show="shouldShowDropdown" id="user-dropdwn">
+        <!-- dropdown content -->
+      </ul>
+    </nav>
+  `,
+  data() {
+    return {
+      shouldShowDropdown: false
+    }
+  }
+}
+```
+
+In this scenario, the element is not visible but but it always rendered. `get()` or `find()` will always return a `Wrapper` – `find()` with `.exists()` always return `true` – because the **element is still in the DOM**. 
+
+## Using `isVisible()`
+
+`isVisible()` gives you the capacity to check whether an element is hidden/shown by using `v-show`.
+
+```js
+test('does not show the user dropdown', () => {
+  const wrapper = mount(Nav)
+
+  // using `get()` works as well
+  expect(wrapper.find('#user-dropdwn').isVisible()).toBe(false)
+})
+```
+
+Note that `isVisible()` is not limited to scenarios using `v-show` as it will check if:
+
+- an element or its ancestors have `display: none`, `visibility: hidden`, `opacity :0` style
+- an element or its ancestors are located inside collapsed `<details>` tag
+- an element or its ancestors have the `hidden` attribute
+
+For any of these cases, `isVisible()` will return `false`.
 
 ## Conclusion
 
-- Use `find()` along with `exists()` to verify whether if an element is in the DOM.
-- Use `get()` if you expect the DOM element to be in the DOM.
+- Use `find()` along with `exists()` to verify whether an element is in the DOM.
+- Use `get()` if you expect the element to be in the DOM.
 - The `data` mounting option can be used to set default values on a component.
+- Use `find()` (or `get()`) with `isVisible()` to verify the visibility of an element that is in the DOM

--- a/src/guide/conditional-rendering.md
+++ b/src/guide/conditional-rendering.md
@@ -119,7 +119,15 @@ In this scenario, the element is not visible but always rendered. `get()` or `fi
 
 ## Using `isVisible()`
 
-`isVisible()` gives you the capacity to check whether an element is hidden/shown by using `v-show`.
+`isVisible()` gives you the capacity to check whether an element is the DOM is hidden. `isVisible()` will check if:
+                                                                                  
+- an element or its ancestors have `display: none`, `visibility: hidden`, `opacity :0` style
+- an element or its ancestors are located inside collapsed `<details>` tag
+- an element or its ancestors have the `hidden` attribute
+
+For any of these cases, `isVisible()` will return `false`.
+
+Testing scenarios using `v-show` will look like:
 
 ```js
 test('does not show the user dropdown', () => {
@@ -127,15 +135,7 @@ test('does not show the user dropdown', () => {
 
   expect(wrapper.get('#user-dropdown').isVisible()).toBe(false)
 })
-```
-
-Note that `isVisible()` is not limited to scenarios using `v-show` as it will check if:
-
-- an element or its ancestors have `display: none`, `visibility: hidden`, `opacity :0` style
-- an element or its ancestors are located inside collapsed `<details>` tag
-- an element or its ancestors have the `hidden` attribute
-
-For any of these cases, `isVisible()` will return `false`.
+``` 
 
 ## Conclusion
 

--- a/src/guide/conditional-rendering.md
+++ b/src/guide/conditional-rendering.md
@@ -119,13 +119,13 @@ In this scenario, the element is not visible but always rendered. `get()` or `fi
 
 ## Using `isVisible()`
 
-`isVisible()` gives you the capacity to check whether an element is the DOM is hidden. `isVisible()` will check if:
+`isVisible()` gives the capacity to check for hidden elements. In particular `isVisible()` will check if:
                                                                                   
 - an element or its ancestors have `display: none`, `visibility: hidden`, `opacity :0` style
 - an element or its ancestors are located inside collapsed `<details>` tag
 - an element or its ancestors have the `hidden` attribute
 
-For any of these cases, `isVisible()` will return `false`.
+For any of these cases, `isVisible()` returns `false`.
 
 Testing scenarios using `v-show` will look like:
 


### PR DESCRIPTION
In this PR I ty to address [this Issue](https://github.com/vuejs/vue-test-utils-next-docs/issues/47) by:

- explaining what `isVisible()` does
- giving an example where `isVisible()` applies
- explaining why `get()`, `find()` and `find() + exists()` are not suitable

I also modify couple sentences with the intent of:

#### enforcing the understanding that `v-if` removes an element from the DOM (contrary to `v-show`)
In the docs, `Vue` uses `render` in an idiosyncratic way, [for example](https://vuejs.org/v2/guide/conditional.html#v-show) when saying that _elements with `v-show` will always be rendered and remain in the DOM`_.

In browser terms though some elements [hidden via CSS will be omitted from the render tree or laid out as empty boxes](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/render-tree-construction?hl=en).

The documentation updates follow the Vue way

#### enforcing the understanding that `get()` assumes existence and `find()` does not

The new section looks like:

||
|-|
|![Screenshot 2020-10-18 at 13 41 14](https://user-images.githubusercontent.com/4223655/96366379-abf14c80-1147-11eb-9b54-be63ef2bf21f.png)|
