### PR TITLE
Add missing docs from latest releases

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -67,7 +67,7 @@ module.exports = {
   locales: {
     '/': {
       lang: 'en-US',
-      title: 'Vue Test Utils (2.0.0-beta.7)'
+      title: 'Vue Test Utils (2.0.0-beta.10)'
     }
   },
   themeConfig: {


### PR DESCRIPTION
When creating https://github.com/vuejs/vue-test-utils-next/pull/252 I noticed we're lacking some API info.

We should start thinking about merging docs, to make sure any code-based PR has also the appropiate documentation update :) 