### PR TITLE
Remove createLocalVue from VTU2 example

### DIFF
--- a/src/guide/migration.md
+++ b/src/guide/migration.md
@@ -76,7 +76,7 @@ const wrapper = mount(App, {
 
 ```js
 import { createStore } from 'vuex'
-import { createLocalVue, mount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 
 const App = {
   computed: {


### PR DESCRIPTION
Remove `createLocalVue` from the After portion of the "No more createLocalVue". Its inclusion was rather confusing, considering how the previous section just told us that we no longer use `createLocalVue` in VTU2 and the `createLocalVue` import is unused in the example.